### PR TITLE
Run pptp as root

### DIFF
--- a/vpn
+++ b/vpn
@@ -8,6 +8,6 @@
 
 if ! /sbin/ifconfig $1 | grep -q "$2"
 then
-	/usr/bin/poff $3
-	/usr/bin/pon $3
+	sudo /usr/bin/poff $3
+	sudo /usr/bin/pon $3
 fi


### PR DESCRIPTION
When trying this out on my machine, the `pon`  and `poff` commands did not produce any error messages (when the output was redirected to a log), but it didn't actually establish a connection. I fixed this by adding `sudo` in front of those two commands. This should probably not affect those people for who it works anyway while fixing the edge cases like me.